### PR TITLE
Enable the usage of environment variables in config.json

### DIFF
--- a/smiler/config.py
+++ b/smiler/config.py
@@ -51,16 +51,16 @@ class config(object):
     
     def check_tools(self):
         err = False
-        if not os.path.exists(config.apksigner_path):
+        if not os.path.exists(os.path.expandvars(config.apksigner_path)):
             err = True
             logging.error("apksigner was not found at {}".format(config.apksigner_path))
-        if not os.path.exists(config.adb_path):
+        if not os.path.exists(os.path.expandvars(config.adb_path)):
             err = True
             logging.error("adb tool was not found at {}".format(config.adb_path))
-        if not os.path.exists(config.aapt_path):
+        if not os.path.exists(os.path.expandvars(config.aapt_path)):
             err = True
             logging.error("aapt tool was not found at {}".format(config.aapt_path))
-        if not os.path.exists(config.zipalign):
+        if not os.path.exists(os.path.expandvars(config.zipalign)):
             err = True
             logging.error("zipalign was not found at {}".format(config.zipalign))
         if err:


### PR DESCRIPTION
Enables the usage of environment variables in the config.json file, e.g., your config could look now as follows:

```
{
  "AAPT": "$ANDROID_HOME/build-tools/30.0.2/aapt",
  "ZIPALIGN": "$ANDROID_HOME/build-tools/30.0.2/zipalign",
  "ADB": "$ANDROID_HOME/platform-tools/adb",
  "APKSIGNER": "$ANDROID_HOME/build-tools/30.0.2/apksigner"
}
```